### PR TITLE
Added a 'past' key to events.yml

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,10 @@ template: overrides/home.html
     
     {% for hackathon in season.hackathons %}
 
-        {% include 'events/card.md' %}
-
+        {% if hackathon.past != True %}
+            {% include 'events/card.md' %}
+        {% endif %}
+        
     {% endfor %}
 
 </div>

--- a/events.yml
+++ b/events.yml
@@ -9,6 +9,7 @@ extra:
           when: 27th-31st July 2020
           attendees: 100
           digital: true
+          past: true
         - name: DurJam
           background: /static/art/hackathon_tiles/durjam_background.png
           logo: /static/art/hackathon_tiles/durjam_logo.png


### PR DESCRIPTION
This allows us to filter events from the homepage that have already happened.

Ideally, it'd just have it figure it out with JS, but the dates aren't ISO so it's a bit of a hassle to fix this right now.