### PR TITLE
Updated events.yaml to add Birmingham open hack

### DIFF
--- a/events.yml
+++ b/events.yml
@@ -1,5 +1,15 @@
 extra:
   hackathon_seasons:
+    - name: Autumn 2021
+      past: false
+      hackathons:
+        - name: Birmingham Open Hack
+          website: https://www.openhack.tech
+          location: Birmingham (Online/Virtual)
+          when: 2nd-3rd October 2021
+          attendees: TBC
+          digital: true
+          
     - name: Summer 2020
       past: true
       hackathons:


### PR DESCRIPTION
Hi there! 
We're back again with Birmingham Open Hack this year. Much more clarity on who's running it. It's basically run by BCU Tech Guild aka the new computer science community for BCU. Same goal as before, get as many students, professionals, and enthusiasts who love tech under one roof to solve a few challenges and win some prizes.

BCU Tech guild twitter: https://twitter.com/bcutechguild?lang=en