### PR TITLE
Add HackNotts 2021 to Events

### DIFF
--- a/events.yml
+++ b/events.yml
@@ -8,6 +8,13 @@ extra:
           location: Royal Holloway
           when: 5th-6th Feburary 2022
           attendees: TBC
+
+        - name: HackNotts 2021
+          website: https://hacknotts.com
+          location: Nottingham
+          when: 12th-13th Feburary 2022
+          attendees: TBC
+          digital: false
       
         - name: DurHack 2022
           website: https://durhack.com/


### PR DESCRIPTION
Good afternoon,

We at HackSoc Nottingham are happy to be hosting HackNotts 2021 in the Ada Lovelace Computing Lab next year in February. For more details you can check out our website!

[HackNotts Website](https://hacknotts.com/) (Not updated yet)
[HackSoc Nottingham Website](https://hacksoc.net/)